### PR TITLE
Fix next level progress calculation and tooltip

### DIFF
--- a/resources/components/player-panel/player-skills.css
+++ b/resources/components/player-panel/player-skills.css
@@ -7,6 +7,7 @@
 }
 
 .skill-box {
+  position: relative;
   display: flex;
   font-family: rstiny, sans-serif;
 }

--- a/resources/components/player-panel/player-skills.tsx
+++ b/resources/components/player-panel/player-skills.tsx
@@ -48,12 +48,15 @@ export const PlayerSkills = ({ member }: { member: Member.Name }): ReactElement 
         const xp = skills?.[skill] ?? (0 as Experience);
         xpTotal += xp;
 
-        const { xpDeltaFromMax, levelReal, levelVirtual, xpMilestoneOfNext } = decomposeExperience(xp);
+        const { xpDeltaFromMax, levelReal, levelVirtual, xpMilestoneOfNext, xpMilestoneOfCurrent } =
+          decomposeExperience(xp);
 
         levelTotal += levelReal;
 
         const wikiURLRaw = `https://oldschool.runescape.wiki/w/${skill}`;
         const iconURLRaw = SkillIconsBySkill[skill];
+
+        const levelProgress = (xp - xpMilestoneOfCurrent) / (xpMilestoneOfNext - xpMilestoneOfCurrent);
 
         return (
           <a
@@ -70,7 +73,7 @@ export const PlayerSkills = ({ member }: { member: Member.Name }): ReactElement 
                 untilMax: Math.max(0, xpDeltaFromMax - xp) as Experience,
                 untilMaxRatio: Math.min(xp / xpDeltaFromMax, 1.0),
                 untilNext: (xpMilestoneOfNext - xp) as Experience,
-                untilNextRatio: Math.min(xp / xpMilestoneOfNext, 1.0),
+                untilNextRatio: Math.min(levelProgress, 1.0),
               })
             }
           >
@@ -82,7 +85,13 @@ export const PlayerSkills = ({ member }: { member: Member.Name }): ReactElement 
               <div className="skill-box-baseline-level">{levelReal}</div>
             </div>
             <div className="skill-box-progress">
-              <div className="skill-box-progress-bar" style={{}}></div>
+              <div
+                className="skill-box-progress-bar"
+                style={{
+                  transform: `scaleX(${levelProgress})`,
+                  background: `hsl(${levelProgress * 100}, 100%, 50%)`,
+                }}
+              ></div>
             </div>
           </a>
         );

--- a/resources/components/tooltip/tooltip.tsx
+++ b/resources/components/tooltip/tooltip.tsx
@@ -23,6 +23,15 @@ export const Tooltip = (): ReactElement => {
       if (!elementRef.current) return;
 
       elementRef.current.style.transform = `translate(${x}px, ${y}px)`;
+
+      const tooltip = elementRef.current.firstElementChild as HTMLElement | null;
+      if (!tooltip) return;
+
+      const rect = tooltip.getBoundingClientRect();
+      const offsetX = x + 5 + rect.width > window.innerWidth ? -(rect.width + 5) : 5;
+      const offsetY = y - rect.height - 5 < 0 ? rect.height + 5 : -(rect.height + 5);
+
+      tooltip.style.transform = `translate(${offsetX}px, ${offsetY}px)`;
     };
     window.addEventListener("pointermove", handlePointerMove);
     return (): void => {


### PR DESCRIPTION
### Changes
- Fixes the values in the skill box tool tip for next level progress
- Fixes the tool tip alignment when near the edge of the screen (useful for aligning skill panels to right of screen)
- Finishes styling for skill panel overlaid progress bar