### PR TITLE
Add recent player activity summaries

### DIFF
--- a/resources/components/achievement-diary/achievement-diary.tsx
+++ b/resources/components/achievement-diary/achievement-diary.tsx
@@ -50,7 +50,7 @@ export const DiaryRegionWindow = ({ region, player, progress, onCloseModal }: Di
             {formatTitle(`${region} achievement diary`)}
           </a>
         </h1>
-        <button className="diary-dialog-close" onClick={onCloseModal}>
+        <button className="diary-dialog-close dialog-close" onClick={onCloseModal}>
           <CachedImage src="/ui/1731-0.png" alt={formatTitle("Close dialog")} title={formatTitle("Close dialog")} />
         </button>
       </div>

--- a/resources/components/achievement-diary/achievement-log.css
+++ b/resources/components/achievement-diary/achievement-log.css
@@ -61,18 +61,6 @@
 .diary-dialog-close {
   position: absolute;
   right: 0;
-  height: 21px;
-  width: 21px;
-}
-
-.diary-dialog-close:hover,
-.diary-dialog-close:focus-visible {
-  outline: solid var(--orange) 1px;
-}
-
-.diary-dialog-close > img {
-  width: 100%;
-  object-fit: contain;
 }
 
 .diary-dialog-title {
@@ -83,10 +71,6 @@
 .diary-dialog-header > div {
   display: flex;
   flex-direction: column;
-}
-
-.dialog-close:hover {
-  filter: brightness(1.3);
 }
 
 .diary-dialog-tier-complete,

--- a/resources/components/app/app.css
+++ b/resources/components/app/app.css
@@ -38,6 +38,22 @@ button {
   font-family: rssmall, ui-sans-serif, Arial, sans-serif;
 }
 
+.dialog-close {
+  display: flex;
+  height: 21px;
+  width: 21px;
+}
+
+.dialog-close:hover,
+.dialog-close:focus-visible {
+  outline: solid var(--orange) 1px;
+}
+
+.dialog-close > img {
+  width: 100%;
+  object-fit: contain;
+}
+
 a {
   color: unset;
 }

--- a/resources/components/collection-log/collection-log.css
+++ b/resources/components/collection-log/collection-log.css
@@ -26,13 +26,7 @@
 }
 
 .collection-log-close {
-  flex: 0;
-  display: flex;
-}
-
-.collection-log-close:hover,
-.collection-log-close:focus-visible {
-  outline: solid var(--orange) 1px;
+  flex-shrink: 0;
 }
 
 .collection-log-search {

--- a/resources/components/collection-log/collection-log.tsx
+++ b/resources/components/collection-log/collection-log.tsx
@@ -354,7 +354,7 @@ export const CollectionLogWindow = ({
           {formatTitle(`${player}'s collection log`)} - {totalCollected} / {collectionLogInfo?.uniqueSlots ?? 0} (Group:{" "}
           {totalGroupCollected} / {collectionLogInfo?.uniqueSlots ?? 0})
         </h1>
-        <button className="collection-log-close dialog__close" onClick={onCloseModal}>
+        <button className="collection-log-close dialog-close" onClick={onCloseModal}>
           <CachedImage src="/ui/1731-0.png" alt="Close dialog" title="Close dialog" />
         </button>
       </div>

--- a/resources/components/player-activity/player-activity.css
+++ b/resources/components/player-activity/player-activity.css
@@ -1,0 +1,324 @@
+.player-activity {
+  width: min(640px, 95vw);
+  max-height: 90svh;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 16px;
+  box-sizing: border-box;
+  color: var(--white);
+}
+
+.player-activity-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+  flex-shrink: 0;
+}
+
+.player-activity-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.player-activity-close {
+  flex-shrink: 0;
+}
+
+.player-activity-footer {
+  margin-top: 1rem;
+  display: flex;
+}
+
+.player-activity-dismiss {
+  flex: 1 1 auto;
+}
+
+.player-activity-since {
+  margin: 0 0 4px;
+  font-size: 0.875rem;
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+.player-activity-empty {
+  opacity: 0.65;
+  font-style: italic;
+}
+
+.player-activity-body {
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.player-activity-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.player-activity-section-title {
+  margin: 0;
+  font-size: 1.1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  padding-bottom: 4px;
+}
+
+.player-activity-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-activity-subsection-title {
+  margin: 0;
+  font-size: 0.875rem;
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Level ups */
+.player-activity-levelups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.player-activity-levelup {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 1rem;
+}
+
+.player-activity-skill-icon {
+  width: 18px;
+  height: 18px;
+  image-rendering: pixelated;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.player-activity-skill-name {
+  font-size: 1rem;
+}
+
+.player-activity-level-change {
+  font-weight: bold;
+  color: var(--orange);
+  margin-left: 2px;
+}
+
+.player-activity-arrow {
+  height: 1em;
+  width: auto;
+  vertical-align: middle;
+  margin: 0 2px;
+}
+
+/* XP list */
+.player-activity-xp-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.player-activity-xp-row {
+  display: grid;
+  grid-template-columns: 20px 1fr auto auto;
+  align-items: center;
+  gap: 6px;
+  font-size: 1rem;
+  padding: 1px 0;
+}
+
+.player-activity-xp-gained {
+  color: var(--green);
+  text-align: right;
+  font-weight: bold;
+}
+
+.player-activity-xp-total {
+  opacity: 0.55;
+  text-align: right;
+  font-size: 0.875rem;
+  min-width: 60px;
+}
+
+/* Quests */
+.player-activity-quest-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.player-activity-quest-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+}
+
+.player-activity-quest-status {
+  font-size: 0.875rem;
+  font-weight: bold;
+  min-width: 70px;
+  flex-shrink: 0;
+}
+
+.player-activity-quest-finished .player-activity-quest-status {
+  color: var(--green);
+}
+
+.player-activity-quest-in-progress .player-activity-quest-status {
+  color: var(--orange);
+}
+
+.player-activity-quest-not-started .player-activity-quest-status {
+  color: var(--red);
+}
+
+.player-activity-quest-name {
+  opacity: 0.9;
+}
+
+/* Achievement diaries */
+.player-activity-diary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.player-activity-diary-region {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.player-activity-diary-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.player-activity-diary-count {
+  color: var(--green);
+  font-size: 0.875rem;
+  font-weight: normal;
+}
+
+.player-activity-diary-tasks {
+  margin: 0;
+  padding: 0 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  list-style-position: outside;
+}
+
+.player-activity-diary-tasks li {
+  font-size: 0.875rem;
+  opacity: 0.85;
+}
+
+.player-activity-diary-tasks li::marker {
+  content: "✓  ";
+}
+
+/* Collection log */
+.player-activity-collection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.player-activity-collection-row {
+  display: flex;
+}
+
+.player-activity-collection-item {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 6px;
+  font-size: 1rem;
+  text-decoration: none;
+  color: inherit;
+  padding: 2px 4px;
+  border-radius: 3px;
+  width: 100%;
+}
+
+.player-activity-collection-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.player-activity-collection-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+  object-fit: contain;
+  justify-self: center;
+}
+
+.player-activity-collection-name {
+  opacity: 0.9;
+}
+
+.player-activity-collection-new {
+  color: var(--orange);
+  font-size: 0.875rem;
+  font-weight: bold;
+}
+
+.player-activity-collection-qty {
+  color: var(--green);
+  font-size: 0.875rem;
+  text-align: right;
+}
+
+.player-activity-counter {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+}
+
+.player-activity-counter .arrow {
+  margin-top: -0.125rem;
+}
+
+.player-activity-bosskc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.player-activity-bosskc-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  padding: 1px 0;
+}
+
+.player-activity-bosskc-change {
+  opacity: 0.55;
+  font-size: 0.875rem;
+}
+
+.player-activity-bosskc-gained {
+  color: var(--green);
+  font-weight: bold;
+  text-align: right;
+  min-width: 48px;
+}

--- a/resources/components/player-activity/player-activity.tsx
+++ b/resources/components/player-activity/player-activity.tsx
@@ -1,0 +1,274 @@
+import { useContext, type ReactElement } from "react";
+import { GameDataContext } from "../../context/game-data-context";
+import { DiaryRegion, DiaryTier } from "../../game/diaries";
+import type * as Member from "../../game/member";
+import { SkillIconsBySkill } from "../../game/skill";
+import type { PlayerActivity } from "../../hooks/player-snapshot";
+import { formatTitle } from "../../ts/format-title";
+import { CachedImage } from "../cached-image/cached-image";
+import mappings from "../collection-log/mappings.json";
+
+import "./player-activity.css";
+
+const formatNumber = (n: number): string => n.toLocaleString();
+
+const formatRelativeTime = (timestamp: number): string => {
+  const diffMs = Date.now() - timestamp;
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  if (diffMins > 0) return `${diffMins}m ago`;
+  return "just now";
+};
+
+type MappingEntry = "kills" | { label: string; lookupKey: string }[] | [];
+
+export const BOSS_KC_KEYS: Set<string> = new Set(
+  Object.entries(mappings as Record<string, MappingEntry>).flatMap(([pageName, entry]) => {
+    if (entry === "kills") return [pageName];
+    if (Array.isArray(entry)) return entry.map((e) => e.lookupKey);
+    return [];
+  }),
+);
+
+export interface PlayerActivityWindowProps {
+  player: Member.Name;
+  activity: PlayerActivity;
+  currentHiscores?: Map<string, number>;
+  onClearSnapshot?: () => void;
+  onCloseModal: () => void;
+}
+
+export const PlayerActivityWindow = ({
+  player,
+  activity,
+  currentHiscores,
+  onClearSnapshot,
+  onCloseModal,
+}: PlayerActivityWindowProps): ReactElement => {
+  const { quests: questData, diaries: diaryData, items: itemData } = useContext(GameDataContext);
+
+  const { skillChanges, questChanges, diaryChanges, collectionChanges, bossKcBefore } = activity;
+  const levelUps = skillChanges.filter((c) => c.levelAfter > c.levelBefore);
+
+  const sortedDiaryChanges = [...diaryChanges].sort((a, b) => {
+    const regionDiff = DiaryRegion.indexOf(a.region) - DiaryRegion.indexOf(b.region);
+    if (regionDiff !== 0) return regionDiff;
+    return DiaryTier.indexOf(a.tier) - DiaryTier.indexOf(b.tier);
+  });
+
+  // Compute boss KC changes once current hiscores have loaded.
+  const hasBossKcBefore = Object.keys(bossKcBefore).length > 0;
+  const bossKcChanges: { boss: string; before: number; after: number }[] | undefined =
+    currentHiscores === undefined
+      ? undefined
+      : Object.entries(bossKcBefore)
+          .filter(([key]) => BOSS_KC_KEYS.has(key))
+          .flatMap(([key, before]) => {
+            const after = currentHiscores.get(key) ?? 0;
+            return after > before ? [{ boss: key, before, after }] : [];
+          })
+          .sort((a, b) => b.after - b.before - (a.after - a.before));
+
+  const handleClear = (): void => {
+    onClearSnapshot?.();
+    onCloseModal();
+  };
+
+  const hasChanges =
+    skillChanges.length > 0 || questChanges.length > 0 || diaryChanges.length > 0 || collectionChanges.length > 0;
+
+  return (
+    <div className="player-activity rsborder rsbackground">
+      <div className="player-activity-header">
+        <h2>{formatTitle(`${player}'s Recent Activity`)}</h2>
+        <button className="player-activity-close dialog-close" onClick={onCloseModal} aria-label="Close">
+          <CachedImage src="/ui/1731-0.png" alt="Close dialog" title="Close dialog" />
+        </button>
+      </div>
+      <p className="player-activity-since">
+        Since {formatRelativeTime(activity.snapshotTimestamp)} - {new Date(activity.snapshotTimestamp).toLocaleString()}
+      </p>
+      {!hasChanges && !hasBossKcBefore && <p className="player-activity-empty">No activity recorded.</p>}
+
+      <div className="player-activity-body">
+        {/* XP gains and level ups */}
+        {skillChanges.length > 0 && (
+          <section className="player-activity-section">
+            <h3 className="player-activity-section-title">{formatTitle("Skills")}</h3>
+            {levelUps.length > 0 && (
+              <div className="player-activity-subsection">
+                <h4 className="player-activity-subsection-title">Level ups</h4>
+                <div className="player-activity-levelups">
+                  {levelUps.map((change) => (
+                    <div key={change.skill} className="player-activity-levelup">
+                      <CachedImage
+                        alt={`${change.skill} icon`}
+                        src={SkillIconsBySkill[change.skill] ?? ""}
+                        className="player-activity-skill-icon"
+                      />
+                      <span className="player-activity-skill-name">{change.skill}</span>
+                      <span className="player-activity-level-change player-activity-counter">
+                        <span>{change.levelBefore}</span>
+                        <span className="arrow">→</span>
+                        <span>{change.levelAfter}</span>
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="player-activity-subsection">
+              <h4 className="player-activity-subsection-title">XP gained</h4>
+              <div className="player-activity-xp-list">
+                {skillChanges.map((change) => (
+                  <div key={change.skill} className="player-activity-xp-row">
+                    <CachedImage
+                      alt={`${change.skill} icon`}
+                      src={SkillIconsBySkill[change.skill] ?? ""}
+                      className="player-activity-skill-icon"
+                    />
+                    <span className="player-activity-skill-name">{change.skill}</span>
+                    <span className="player-activity-xp-gained">+{formatNumber(change.xpAfter - change.xpBefore)}</span>
+                    <span className="player-activity-xp-total">{formatNumber(change.xpAfter)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Quest changes */}
+        {questChanges.length > 0 && (
+          <section className="player-activity-section">
+            <h3 className="player-activity-section-title">{formatTitle("Quests")}</h3>
+            <div className="player-activity-quest-list">
+              {questChanges.map((change) => {
+                const questName = questData?.get(change.questId)?.name ?? `Quest #${change.questId}`;
+                const statusLabel =
+                  change.statusAfter === "FINISHED"
+                    ? "Completed"
+                    : change.statusAfter === "IN_PROGRESS"
+                      ? "Started"
+                      : "Not started";
+                const statusClass =
+                  change.statusAfter === "FINISHED"
+                    ? "player-activity-quest-finished"
+                    : change.statusAfter === "IN_PROGRESS"
+                      ? "player-activity-quest-in-progress"
+                      : "player-activity-quest-not-started";
+
+                return (
+                  <div key={String(change.questId)} className={`player-activity-quest-row ${statusClass}`}>
+                    <span className="player-activity-quest-status">{statusLabel}</span>
+                    <span className="player-activity-quest-name">{questName}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Diary changes */}
+        {diaryChanges.length > 0 && (
+          <section className="player-activity-section">
+            <h3 className="player-activity-section-title">{formatTitle("Achievement diaries")}</h3>
+            <div className="player-activity-diary-list">
+              {sortedDiaryChanges.map((change) => {
+                const regionTasks = diaryData?.get(change.region)?.get(change.tier);
+                return (
+                  <div key={`${change.region}-${change.tier}`} className="player-activity-diary-region">
+                    <span className="player-activity-diary-header">
+                      {change.region} - {change.tier}
+                      <span className="player-activity-diary-count">
+                        +{change.newlyCompletedIndices.length} task
+                        {change.newlyCompletedIndices.length !== 1 ? "s" : ""}
+                      </span>
+                    </span>
+                    {regionTasks && (
+                      <ul className="player-activity-diary-tasks">
+                        {change.newlyCompletedIndices.map((idx) => (
+                          <li key={idx}>{regionTasks[idx]?.task ?? `Task #${idx + 1}`}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Collection log changes */}
+        {collectionChanges.length > 0 && (
+          <section className="player-activity-section">
+            <h3 className="player-activity-section-title">{formatTitle("Collection log")}</h3>
+            <div className="player-activity-collection-list">
+              {collectionChanges.map((change) => {
+                const itemName = itemData?.get(change.itemId)?.name ?? `Item #${change.itemId}`;
+                const isNew = change.quantityBefore === 0;
+                return (
+                  <div key={String(change.itemId)} className="player-activity-collection-row">
+                    <a
+                      href={`https://oldschool.runescape.wiki/w/Special:Lookup?type=item&id=${change.itemId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="player-activity-collection-item"
+                    >
+                      <CachedImage
+                        alt={itemName}
+                        src={`/item-icons/${change.itemId}.webp`}
+                        className="player-activity-collection-icon"
+                      />
+                      <span className="player-activity-collection-name">{itemName}</span>
+                      {isNew ? (
+                        <span className="player-activity-collection-new">New!</span>
+                      ) : (
+                        <div className="player-activity-collection-qty player-activity-counter">
+                          <span>{change.quantityBefore}</span>
+                          <span className="arrow">→</span>
+                          <span>{change.quantityAfter}</span>
+                        </div>
+                      )}
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Boss kill counts */}
+        {hasBossKcBefore && bossKcChanges !== undefined && bossKcChanges.length > 0 && (
+          <section className="player-activity-section">
+            <h3 className="player-activity-section-title">{formatTitle("Boss kills")}</h3>
+            <div className="player-activity-bosskc-list">
+              {bossKcChanges.map(({ boss, before, after }) => (
+                <div key={boss} className="player-activity-bosskc-row">
+                  <span className="player-activity-bosskc-name">{boss}</span>
+                  <span className="player-activity-bosskc-change player-activity-counter">
+                    <span>{formatNumber(before)}</span>
+                    <span className="arrow">→</span>
+                    <span>{formatNumber(after)}</span>
+                  </span>
+                  <span className="player-activity-bosskc-gained">+{formatNumber(after - before)}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+
+      {onClearSnapshot && (
+        <div className="player-activity-footer">
+          <button className="player-activity-dismiss men-button small" type="button" onClick={handleClear}>
+            Clear Activity
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/resources/components/player-panel/player-panel.css
+++ b/resources/components/player-panel/player-panel.css
@@ -51,3 +51,41 @@ button.player-panel-tab-active {
 .player-panel-content > * {
   margin: 8px 0;
 }
+
+.player-panel-activity-row {
+  display: flex;
+}
+
+.player-panel-activity-btn {
+  flex: 1;
+  background: rgba(255, 200, 50, 0.15);
+  border: 1px solid rgba(255, 200, 50, 0.4);
+  border-right: none;
+  color: rgb(255, 200, 50);
+  font-size: 0.8rem;
+  padding: 3px 6px;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.15s;
+}
+
+.player-panel-activity-btn:hover {
+  background: rgba(255, 200, 50, 0.28);
+}
+
+.player-panel-activity-clear {
+  background: rgba(255, 200, 50, 0.1);
+  border: 1px solid rgba(255, 200, 50, 0.4);
+  color: rgb(255, 200, 50);
+  font-size: 0.75rem;
+  padding: 3px 7px;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.player-panel-activity-clear:hover {
+  background: rgba(255, 100, 80, 0.25);
+  border-color: rgba(255, 100, 80, 0.5);
+  color: rgb(255, 140, 120);
+}

--- a/resources/components/player-panel/player-panel.tsx
+++ b/resources/components/player-panel/player-panel.tsx
@@ -1,14 +1,20 @@
-import { useCallback, useState, type ReactElement } from "react";
-import { PlayerSkills } from "./player-skills";
-import { PlayerInventory } from "./player-inventory";
-import { PlayerEquipment } from "./player-equipment";
-import { PlayerStats, PlayerStatsPlaceholder } from "./player-stats";
-import { PlayerQuests } from "./player-quests";
-import { PlayerDiaries } from "./player-diaries";
+import { useCallback, useContext, useEffect, useState, type ReactElement } from "react";
+import { Context as APIContext } from "../../context/api-context";
+import { GroupMemberStatesContext } from "../../context/group-context";
+import { SettingsContext } from "../../context/settings-context";
+import { SnapshotContext } from "../../context/snapshot-context";
 import * as Member from "../../game/member";
-import { useModal } from "../modal/modal";
-import { CollectionLogWindow } from "../collection-log/collection-log";
+import { activityHasChanges, computeActivity, type PlayerActivity } from "../../hooks/player-snapshot";
 import { CachedImage } from "../cached-image/cached-image";
+import { CollectionLogWindow } from "../collection-log/collection-log";
+import { useModal } from "../modal/modal";
+import { BOSS_KC_KEYS, PlayerActivityWindow } from "../player-activity/player-activity";
+import { PlayerDiaries } from "./player-diaries";
+import { PlayerEquipment } from "./player-equipment";
+import { PlayerInventory } from "./player-inventory";
+import { PlayerQuests } from "./player-quests";
+import { PlayerSkills } from "./player-skills";
+import { PlayerStats, PlayerStatsPlaceholder } from "./player-stats";
 
 import "./player-panel.css";
 
@@ -30,6 +36,45 @@ interface PlayerPanelButtonProps {
 export const PlayerPanel = ({ member }: { member?: Member.Name }): ReactElement => {
   const [subcategory, setSubcategory] = useState<PlayerPanelSubcategory>();
   const { open: openCollectionLogModal, modal: collectionLogModal } = useModal(CollectionLogWindow);
+
+  const [readActivity, setReadActivity] = useState<PlayerActivity>();
+  const { open: openActivityModal, modal: activityModal } = useModal(PlayerActivityWindow);
+
+  const { getBaselineSnapshot, clearBaselineSnapshot } = useContext(SnapshotContext);
+  const memberStates = useContext(GroupMemberStatesContext);
+  const { enableRecentActivity } = useContext(SettingsContext);
+  const { fetchMemberHiscores } = useContext(APIContext)?.api ?? {};
+
+  const baseline = member ? getBaselineSnapshot(member) : undefined;
+  const currentState = member ? memberStates.get(member) : undefined;
+  const activity = baseline && currentState ? computeActivity(baseline, currentState) : undefined;
+  const hasActivity = activity ? activityHasChanges(activity) : false;
+
+  const [hiscores, setHiscores] = useState<Map<string, number>>();
+
+  useEffect(() => {
+    if (!baseline?.bossKc || !fetchMemberHiscores || !member) return;
+    fetchMemberHiscores(member)
+      .then(setHiscores)
+      .catch(() => setHiscores(new Map()));
+  }, [baseline, fetchMemberHiscores, member]);
+
+  const hasBossKcChanges =
+    hiscores !== undefined && baseline?.bossKc !== undefined
+      ? Object.entries(baseline.bossKc).some(
+          ([key, before]) => BOSS_KC_KEYS.has(key) && (hiscores.get(key) ?? 0) > before,
+        )
+      : false;
+
+  const isRead = readActivity !== undefined;
+  const showActivityRow =
+    enableRecentActivity && (isRead || ((hasActivity || hasBossKcChanges) && activity !== undefined));
+  const activityToDisplay = readActivity ?? activity;
+
+  const handleClear = useCallback(() => {
+    if (member) clearBaselineSnapshot(member);
+    setReadActivity(undefined);
+  }, [clearBaselineSnapshot, member]);
 
   const toggleCategory = useCallback(
     (newSubcategory: PlayerPanelSubcategory) => {
@@ -157,8 +202,35 @@ export const PlayerPanel = ({ member }: { member?: Member.Name }): ReactElement 
   return (
     <>
       {collectionLogModal}
+      {activityModal}
       <div className={`player-panel rsborder rsbackground ${content !== undefined ? "expanded" : ""}`}>
         <PlayerStats member={member} />
+
+        {showActivityRow && activityToDisplay && (
+          <div className="player-panel-activity-row">
+            <button
+              className="player-panel-activity-btn"
+              type="button"
+              aria-label={isRead ? "View recent activity" : "View recent activity"}
+              onClick={() => {
+                const frozen = readActivity ?? activity!;
+                if (!isRead) setReadActivity(activity!);
+                openActivityModal({
+                  player: member,
+                  activity: frozen,
+                  currentHiscores: hiscores,
+                  onClearSnapshot: handleClear,
+                });
+              }}
+            >
+              {isRead ? "View recent activity" : "New recent activity!"}
+            </button>
+            <button className="player-panel-activity-clear" type="button" aria-label="Dismiss" onClick={handleClear}>
+              ✕
+            </button>
+          </div>
+        )}
+
         <div className="player-panel-minibar">{buttons}</div>
         <div className="player-panel-content">{content}</div>
       </div>

--- a/resources/components/settings/settings.css
+++ b/resources/components/settings/settings.css
@@ -75,3 +75,14 @@
 .settings-page-radio-item input:focus-visible {
   outline: none;
 }
+
+.settings-page-number-item {
+  padding-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-page-number-item input[type="number"] {
+  width: 72px;
+}

--- a/resources/components/settings/settings.tsx
+++ b/resources/components/settings/settings.tsx
@@ -230,7 +230,16 @@ const EditMemberInput = ({ member }: { member: Member.Name }): ReactElement => {
  * A component that contains fields for tweaking site settings such as sidebar position, and group settings like member names.
  */
 export const SettingsPage = (): ReactElement => {
-  const { siteTheme, setSiteTheme, sidebarPosition, setSidebarPosition } = useContext(SettingsContext);
+  const {
+    siteTheme,
+    setSiteTheme,
+    sidebarPosition,
+    setSidebarPosition,
+    snapshotIntervalMinutes,
+    setSnapshotIntervalMinutes,
+    enableRecentActivity,
+    setEnableRecentActivity,
+  } = useContext(SettingsContext);
   const members = useContext(GroupMemberNamesContext);
   const [addMemberErrors, setAddMemberErrors] = useState<string[]>();
   const addMemberInputRef = useRef<HTMLInputElement>(null);
@@ -384,6 +393,36 @@ export const SettingsPage = (): ReactElement => {
             </div>
           );
         })}
+      </fieldset>
+
+      <fieldset>
+        <legend>{formatTitle("Player Activity Settings")}</legend>
+        <div className="settings-page-radio-item">
+          <input
+            id="enable-recent-activity-input"
+            type="checkbox"
+            checked={enableRecentActivity}
+            onChange={(e) => setEnableRecentActivity?.(e.target.checked)}
+          />
+          <label htmlFor="enable-recent-activity-input">Show recent activity summaries on player panels</label>
+        </div>
+        <div className="settings-page-number-item">
+          <input
+            id="snapshot-interval-input"
+            type="number"
+            min={0}
+            step={1}
+            value={snapshotIntervalMinutes}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              const n = parseInt(raw, 10);
+              if (Number.isInteger(n) && n >= 0) {
+                setSnapshotIntervalMinutes?.(String(n));
+              }
+            }}
+          />
+          <label htmlFor="snapshot-interval-input">minutes between snapshots to show recent activity</label>
+        </div>
       </fieldset>
     </div>
   );

--- a/resources/context/settings-context.tsx
+++ b/resources/context/settings-context.tsx
@@ -7,8 +7,18 @@ interface Settings {
   setSiteTheme?: (value: SiteTheme) => void;
   sidebarPosition: SidebarPosition;
   setSidebarPosition?: (value: SidebarPosition) => void;
+  enableRecentActivity: boolean;
+  setEnableRecentActivity?: (value: boolean) => void;
+  snapshotIntervalMinutes: string;
+  setSnapshotIntervalMinutes?: (value: string) => void;
 }
-const DEFAULT_SITE_SETTINGS = Object.freeze({ sidebarPosition: "left", siteTheme: "light" });
+
+const DEFAULT_SITE_SETTINGS = Object.freeze({
+  sidebarPosition: "left" as SidebarPosition,
+  siteTheme: "light" as SiteTheme,
+  snapshotIntervalMinutes: "60",
+  enableRecentActivity: true,
+});
 
 /* eslint-disable react-refresh/only-export-components */
 
@@ -22,6 +32,17 @@ export const SettingsContext = createContext<Settings>(DEFAULT_SITE_SETTINGS);
 
 const KEY_SITE_THEME = "settings-site-theme";
 const KEY_SIDEBAR_POSITION = "settings-sidebar-position";
+const KEY_RECENT_ACTIVITY = "settings-recent-activity";
+
+interface RecentActivitySettings {
+  enabled: boolean;
+  intervalMinutes: number;
+}
+
+const DEFAULT_RECENT_ACTIVITY: RecentActivitySettings = {
+  enabled: true,
+  intervalMinutes: 60,
+};
 
 const validateSiteTheme = (value: string | undefined): SiteTheme | undefined => {
   const validated = SiteTheme.find((theme) => theme === value);
@@ -30,6 +51,19 @@ const validateSiteTheme = (value: string | undefined): SiteTheme | undefined => 
 const validateSidebarPosition = (value: string | undefined): SidebarPosition | undefined => {
   const validated = SidebarPosition.find((position) => position === value);
   return validated;
+};
+const validateRecentActivitySettings = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj["enabled"] !== "boolean") return undefined;
+    if (!Number.isInteger(obj["intervalMinutes"]) || (obj["intervalMinutes"] as number) < 0) return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
 };
 
 /**
@@ -46,9 +80,45 @@ export const SettingsProvider = ({ children }: { children: ReactNode }): ReactEl
     defaultValue: DEFAULT_SITE_SETTINGS.sidebarPosition,
     validator: validateSidebarPosition,
   });
+  const [recentActivityStr, setRecentActivityStr] = useLocalStorage<string>({
+    key: KEY_RECENT_ACTIVITY,
+    defaultValue: JSON.stringify(DEFAULT_RECENT_ACTIVITY),
+    validator: validateRecentActivitySettings,
+  });
+
+  let recentActivity: RecentActivitySettings;
+  try {
+    recentActivity = JSON.parse(recentActivityStr) as RecentActivitySettings;
+  } catch {
+    recentActivity = DEFAULT_RECENT_ACTIVITY;
+  }
+
+  const enableRecentActivity = recentActivity.enabled;
+  const snapshotIntervalMinutes = String(recentActivity.intervalMinutes);
+
+  const setEnableRecentActivity = (value: boolean): void => {
+    setRecentActivityStr(JSON.stringify({ ...recentActivity, enabled: value }));
+  };
+  const setSnapshotIntervalMinutes = (value: string): void => {
+    const n = parseInt(value, 10);
+    if (Number.isInteger(n) && n >= 0) {
+      setRecentActivityStr(JSON.stringify({ ...recentActivity, intervalMinutes: n }));
+    }
+  };
 
   return (
-    <SettingsContext value={{ siteTheme, sidebarPosition, setSidebarPosition, setSiteTheme }}>
+    <SettingsContext
+      value={{
+        siteTheme,
+        sidebarPosition,
+        setSidebarPosition,
+        setSiteTheme,
+        snapshotIntervalMinutes,
+        setSnapshotIntervalMinutes,
+        enableRecentActivity,
+        setEnableRecentActivity,
+      }}
+    >
       {children}
     </SettingsContext>
   );

--- a/resources/context/snapshot-context.tsx
+++ b/resources/context/snapshot-context.tsx
@@ -1,0 +1,132 @@
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
+import * as Member from "../game/member";
+import { Context as APIContext } from "./api-context";
+import { GroupMemberStatesContext } from "./group-context";
+import { SettingsContext } from "./settings-context";
+import { type PlayerSnapshot, loadSnapshot, saveSnapshot, snapshotFromMemberState } from "../hooks/player-snapshot";
+
+interface SnapshotContextValue {
+  getBaselineSnapshot: (playerName: Member.Name) => PlayerSnapshot | undefined;
+  clearBaselineSnapshot: (playerName: Member.Name) => void;
+}
+
+export const SnapshotContext = createContext<SnapshotContextValue>({
+  getBaselineSnapshot: () => undefined,
+  clearBaselineSnapshot: () => undefined,
+});
+
+export const snapshotIntervalToMs = (minutes: string): number => Math.max(0, Number(minutes)) * 60 * 1000;
+
+/**
+ * Manages player data snapshots in localStorage.
+ *
+ * On each session, when live player data first arrives:
+ * - If a stored snapshot exists and is older than the configured interval,
+ *   it becomes the "baseline" for recent activity and a fresh snapshot is saved.
+ * - If no stored snapshot exists, a fresh snapshot is saved (no activity yet).
+ * - If a stored snapshot exists but is too recent, it is left unchanged.
+ */
+export const SnapshotProvider = ({ children }: { children: ReactNode }): ReactNode => {
+  const apiContext = useContext(APIContext);
+  const memberStates = useContext(GroupMemberStatesContext);
+  const { snapshotIntervalMinutes } = useContext(SettingsContext);
+
+  // Baseline snapshots: loaded at session start for each member, locked for the session.
+  const [baselineSnapshots, setBaselineSnapshots] = useState<Map<Member.Name, PlayerSnapshot>>(new Map());
+
+  // Tracks members whose snapshot has already been handled this session.
+  const handledMembersRef = useRef<Set<Member.Name>>(new Set());
+
+  const api = apiContext?.api;
+
+  // Reset when the API changes (new login / logout).
+  useEffect(() => {
+    setBaselineSnapshots(new Map());
+    handledMembersRef.current = new Set();
+  }, [api]);
+
+  useEffect(() => {
+    if (!api) return;
+
+    const groupName = api.getCredentials().name;
+    const intervalMs = snapshotIntervalToMs(snapshotIntervalMinutes);
+    const now = Date.now();
+
+    let baselineChanged = false;
+    const newBaselines = new Map(baselineSnapshots);
+
+    for (const [memberName, state] of memberStates) {
+      if (handledMembersRef.current.has(memberName)) continue;
+      handledMembersRef.current.add(memberName);
+
+      const existing = loadSnapshot(groupName, memberName);
+
+      const saveFreshWithHiscores = (fresh: PlayerSnapshot): void => {
+        saveSnapshot(groupName, memberName, fresh);
+        api
+          .fetchMemberHiscores(memberName)
+          .then((hiscores) => {
+            const bossKc: Record<string, number> = Object.fromEntries(hiscores);
+            const stored = loadSnapshot(groupName, memberName);
+            if (stored && stored.timestamp === fresh.timestamp) {
+              saveSnapshot(groupName, memberName, { ...stored, bossKc });
+            }
+          })
+          .catch(() => {
+            /* hiscores unavailable — bossKc stays absent */
+          });
+      };
+
+      if (existing && now - existing.timestamp >= intervalMs) {
+        newBaselines.set(memberName, existing);
+        baselineChanged = true;
+        saveFreshWithHiscores({ timestamp: now, ...snapshotFromMemberState(state) });
+      } else if (!existing) {
+        saveFreshWithHiscores({ timestamp: now, ...snapshotFromMemberState(state) });
+      }
+    }
+
+    if (baselineChanged) {
+      setBaselineSnapshots(newBaselines);
+    }
+  }, [memberStates, api]);
+
+  const getBaselineSnapshot = (playerName: Member.Name): PlayerSnapshot | undefined =>
+    baselineSnapshots.get(playerName);
+
+  const clearBaselineSnapshot = useCallback(
+    (playerName: Member.Name): void => {
+      const currentState = memberStates.get(playerName);
+      if (api && currentState) {
+        const groupName = api.getCredentials().name;
+        const fresh: PlayerSnapshot = {
+          timestamp: Date.now(),
+          ...snapshotFromMemberState(currentState),
+        };
+        saveSnapshot(groupName, playerName, fresh);
+        api
+          .fetchMemberHiscores(playerName)
+          .then((hiscores) => {
+            const bossKc: Record<string, number> = Object.fromEntries(hiscores);
+            const stored = loadSnapshot(groupName, playerName);
+            if (stored && stored.timestamp === fresh.timestamp) {
+              saveSnapshot(groupName, playerName, { ...stored, bossKc });
+            }
+          })
+          .catch(() => {
+            /* hiscores unavailable — bossKc stays absent */
+          });
+      }
+
+      setBaselineSnapshots((prev) => {
+        if (!prev.has(playerName)) return prev;
+        const next = new Map(prev);
+        next.delete(playerName);
+        return next;
+      });
+    },
+    [api, memberStates],
+  );
+
+  return <SnapshotContext value={{ getBaselineSnapshot, clearBaselineSnapshot }}>{children}</SnapshotContext>;
+};

--- a/resources/hooks/player-snapshot.ts
+++ b/resources/hooks/player-snapshot.ts
@@ -1,0 +1,192 @@
+import type { DiaryRegion, DiaryTier } from "../game/diaries";
+import type { ItemID } from "../game/items";
+import type { QuestID, QuestStatus } from "../game/quests";
+import type { Experience, Skill } from "../game/skill";
+import type * as Member from "../game/member";
+import { decomposeExperience } from "../game/skill";
+
+/**
+ * A snapshot of a player's relevant tracked state at a point in time.
+ * This is serialized to/from localStorage as JSON.
+ */
+export interface PlayerSnapshot {
+  timestamp: number;
+  skills: Partial<Record<Skill, number>>;
+  quests: Record<string, QuestStatus>;
+  diaries: Partial<Record<DiaryRegion, Partial<Record<DiaryTier, boolean[]>>>>;
+  collection: Record<string, number>;
+  bossKc?: Record<string, number>;
+}
+
+export interface SkillChange {
+  skill: Skill;
+  xpBefore: number;
+  xpAfter: number;
+  levelBefore: number;
+  levelAfter: number;
+}
+
+export interface QuestChange {
+  questId: QuestID;
+  statusBefore: QuestStatus | undefined;
+  statusAfter: QuestStatus;
+}
+
+export interface DiaryChange {
+  region: DiaryRegion;
+  tier: DiaryTier;
+  newlyCompletedIndices: number[];
+}
+
+export interface CollectionChange {
+  itemId: ItemID;
+  quantityBefore: number;
+  quantityAfter: number;
+}
+
+export interface PlayerActivity {
+  snapshotTimestamp: number;
+  skillChanges: SkillChange[];
+  questChanges: QuestChange[];
+  diaryChanges: DiaryChange[];
+  collectionChanges: CollectionChange[];
+  bossKcBefore: Record<string, number>;
+}
+
+export const snapshotFromMemberState = (state: Member.State): Omit<PlayerSnapshot, "timestamp"> => {
+  const skills: Partial<Record<Skill, number>> = {};
+  if (state.skills) {
+    for (const [skill, xp] of Object.entries(state.skills) as [Skill, Experience][]) {
+      skills[skill] = xp;
+    }
+  }
+
+  const quests: Record<string, QuestStatus> = {};
+  if (state.quests) {
+    for (const [id, status] of state.quests) {
+      quests[String(id)] = status;
+    }
+  }
+
+  const diaries: Partial<Record<DiaryRegion, Partial<Record<DiaryTier, boolean[]>>>> = {};
+  if (state.diaries) {
+    for (const [region, tierMap] of Object.entries(state.diaries) as [DiaryRegion, Record<DiaryTier, boolean[]>][]) {
+      diaries[region] = {};
+      for (const [tier, tasks] of Object.entries(tierMap) as [DiaryTier, boolean[]][]) {
+        diaries[region]![tier] = [...tasks];
+      }
+    }
+  }
+
+  const collection: Record<string, number> = {};
+  if (state.collection) {
+    for (const [id, qty] of state.collection) {
+      collection[String(id)] = qty;
+    }
+  }
+
+  return { skills, quests, diaries, collection };
+};
+
+export const computeActivity = (snapshot: PlayerSnapshot, current: Member.State): PlayerActivity => {
+  const skillChanges: SkillChange[] = [];
+  if (current.skills) {
+    for (const [skill, xpAfter] of Object.entries(current.skills) as [Skill, Experience][]) {
+      const xpBefore = snapshot.skills[skill] ?? 0;
+      if (xpAfter > xpBefore) {
+        skillChanges.push({
+          skill,
+          xpBefore,
+          xpAfter,
+          levelBefore: decomposeExperience(xpBefore as Experience).levelReal,
+          levelAfter: decomposeExperience(xpAfter).levelReal,
+        });
+      }
+    }
+  }
+
+  const questChanges: QuestChange[] = [];
+  if (current.quests) {
+    for (const [id, statusAfter] of current.quests) {
+      const statusBefore = snapshot.quests[String(id)] as QuestStatus | undefined;
+      if (statusAfter !== statusBefore) {
+        questChanges.push({ questId: id, statusBefore, statusAfter });
+      }
+    }
+  }
+
+  const diaryChanges: DiaryChange[] = [];
+  if (current.diaries) {
+    for (const [region, tierMap] of Object.entries(current.diaries) as [DiaryRegion, Record<DiaryTier, boolean[]>][]) {
+      for (const [tier, tasks] of Object.entries(tierMap) as [DiaryTier, boolean[]][]) {
+        const oldTasks = snapshot.diaries[region]?.[tier] ?? [];
+        const newlyCompletedIndices: number[] = [];
+        for (let i = 0; i < tasks.length; i++) {
+          if (tasks[i] && !oldTasks[i]) {
+            newlyCompletedIndices.push(i);
+          }
+        }
+        if (newlyCompletedIndices.length > 0) {
+          diaryChanges.push({ region, tier, newlyCompletedIndices });
+        }
+      }
+    }
+  }
+
+  const collectionChanges: CollectionChange[] = [];
+  if (current.collection) {
+    for (const [id, qtyAfter] of current.collection) {
+      const qtyBefore = snapshot.collection[String(id)] ?? 0;
+      if (qtyAfter > qtyBefore) {
+        collectionChanges.push({
+          itemId: id,
+          quantityBefore: qtyBefore,
+          quantityAfter: qtyAfter,
+        });
+      }
+    }
+  }
+
+  return {
+    snapshotTimestamp: snapshot.timestamp,
+    skillChanges,
+    questChanges,
+    diaryChanges,
+    collectionChanges,
+    bossKcBefore: snapshot.bossKc ?? {},
+  };
+};
+
+export const activityHasChanges = (activity: PlayerActivity): boolean => {
+  return (
+    activity.skillChanges.length > 0 ||
+    activity.questChanges.length > 0 ||
+    activity.diaryChanges.length > 0 ||
+    activity.collectionChanges.length > 0
+  );
+};
+
+export const snapshotStorageKey = (groupName: string, playerName: string): string =>
+  `gimhub-snapshot-v1-${groupName}-${playerName}`;
+
+export const loadSnapshot = (groupName: string, playerName: string): PlayerSnapshot | undefined => {
+  try {
+    const raw = localStorage.getItem(snapshotStorageKey(groupName, playerName));
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj["timestamp"] !== "number") return undefined;
+    return obj as unknown as PlayerSnapshot;
+  } catch {
+    return undefined;
+  }
+};
+
+export const saveSnapshot = (groupName: string, playerName: string, snapshot: PlayerSnapshot): void => {
+  try {
+    localStorage.setItem(snapshotStorageKey(groupName, playerName), JSON.stringify(snapshot));
+  } catch {
+    // localStorage full or unavailable; silently ignore
+  }
+};

--- a/resources/views/index.tsx
+++ b/resources/views/index.tsx
@@ -7,6 +7,7 @@ import { GameDataProvider } from "../context/game-data-context";
 import { SettingsProvider } from "../context/settings-context";
 import { GroupProvider } from "../context/group-context";
 import { ImageProvider } from "../context/image-provider";
+import { SnapshotProvider } from "../context/snapshot-context";
 
 import "../api/fetch-with-csrf";
 
@@ -19,9 +20,11 @@ createRoot(root).render(
         <GameDataProvider>
           <GroupProvider>
             <SettingsProvider>
-              <BrowserRouter>
-                <App />
-              </BrowserRouter>
+              <SnapshotProvider>
+                <BrowserRouter>
+                  <App />
+                </BrowserRouter>
+              </SnapshotProvider>
             </SettingsProvider>
           </GroupProvider>
         </GameDataProvider>


### PR DESCRIPTION
One feature that I thought would be really neat to have is some way to see what your group has been up to since you last checked in. This pull request adds a per-player "Recent Activity" feature that compares a player's current state against a periodic snapshot stored in their browser's localStorage, showing changes in skills, quests, achievement diaries, collection log items, and boss kc.

### New Features
- **Recent Activity modal**: Opens from the player panel when new activity is detected since the last snapshot. Shows skill XP/level changes, quest completions/starts, achievement diary task completions, collection log additions, and boss kill counts.
- **Configurable snapshot interval**: Controlled via existing settings; activity is only shown once the stored snapshot is older than the configured threshold. Additionally, the feature may be disabled entirely.

### Changes
- **Shared close button style**: `.dialog-close` utility in `app.css` standardizes the close button appearance across all three current modals (achievement diary, collection log, and now recent activity)

### Screenshots
An example of a recent activity modal (the values are all manual, so XP values and levels aren't necessarily correct):

<img width="670" height="1089" alt="image" src="https://github.com/user-attachments/assets/009873a8-1d8f-4765-aa9f-b9cd37793826" />

More realistic short-term summary, with clear activity button to reset the interval:

<img width="664" height="226" alt="image" src="https://github.com/user-attachments/assets/ed9fb2de-e19e-472e-ae40-3f1826995b4b" />

New recent activity indicator and dismiss button:

<img width="309" height="146" alt="image" src="https://github.com/user-attachments/assets/11279279-a17c-4bdb-b19f-b77f153b522c" />

Additional appearance settings:

<img width="508" height="307" alt="image" src="https://github.com/user-attachments/assets/55bb1eac-2622-4ec8-a0a3-bfa5d303a351" />
