### PR TITLE
fix: tweak mad angel mappings

### DIFF
--- a/resources/components/collection-log/mappings.json
+++ b/resources/components/collection-log/mappings.json
@@ -42,7 +42,7 @@
   "Kree'arra": [{ "label": "Kree'arra kills", "lookupKey": "Kree'Arra" }],
   "K'ril Tsutsaroth": "kills",
   "The Leviathan": "kills",
-  "The Mad Angel": "kills",
+  "The Mad Angel": [{ "label": "Mad Angel kills", "lookupKey": "Mad Angel" }],
   "Maggot King": "kills",
   "Moons of Peril": [{ "label": "Lunar Chests opened", "lookupKey": "Lunar Chests" }],
   "Nex": "kills",


### PR DESCRIPTION
Just a quick line tweak to the Mad Angel boss mappings (in-game has "the" and hiscores doesn't, for some strange reason).