### PR TITLE
fix(history): duplicate/stale rows in skill history table

### DIFF
--- a/resources/components/skill-graph/SkillGraph.vue
+++ b/resources/components/skill-graph/SkillGraph.vue
@@ -100,7 +100,6 @@
       const fillPercent = Math.max(0.1, 100 * row.fillFraction);
       return {
         ...row,
-        key: `${row.name} ${row.iconSource} ${row.isMemberHeader}`,
         background: `linear-gradient(90deg, ${row.colorCSS} ${fillPercent}%, transparent ${fillPercent}%)`,
       };
     });

--- a/resources/components/skill-graph/skill-graph-data.js
+++ b/resources/components/skill-graph/skill-graph-data.js
@@ -154,6 +154,7 @@ export function buildTableRowsFromMemberSkillData(members, range, options) {
   for (const { name, total, perSkill, colorCSS } of groupMetrics) {
     if (options.skillFilter !== "Overall") {
       rows.push({
+        key: `member ${name}`,
         name,
         colorCSS: "hsl(69deg, 60%, 60%)",
         fillFraction: total / safeDenominator,
@@ -166,6 +167,7 @@ export function buildTableRowsFromMemberSkillData(members, range, options) {
 
     const overallFraction = total / safeDenominator;
     rows.push({
+      key: `member ${name}`,
       name,
       colorCSS,
       fillFraction: overallFraction,
@@ -184,6 +186,7 @@ export function buildTableRowsFromMemberSkillData(members, range, options) {
       }
 
       skillRows.push({
+        key: `skill ${skill} ${name}`,
         name: skill,
         colorCSS,
         fillFraction: (metricValue / total) * overallFraction,

--- a/resources/js/tests/skill-graph-data.test.js
+++ b/resources/js/tests/skill-graph-data.test.js
@@ -75,6 +75,37 @@ describe("skill history calculations", function describeCalculations() {
     expect(buildTableRowsFromMemberSkillData(data, range, options)).toEqual([]);
   });
 
+  it("keys table rows by member and skill so two members gaining the same skill never share a key", function testUniqueRowKeys() {
+    function memberEntry(name, samples) {
+      return {
+        member: name,
+        skillSamples: samples,
+        style: { lineBorder: "red", lineBackground: "red", barBackground: "red" },
+      };
+    }
+    // Alice and Bob both gain Attack experience during the visible hour.
+    const data = [
+      memberEntry("Alice", [sample("11:55", 100), sample("12:30", 400)]),
+      memberEntry("Bob", [sample("11:55", 50), sample("12:30", 150)]),
+    ];
+    const rows = buildTableRowsFromMemberSkillData(data, range, {
+      skillFilter: "Overall",
+      yAxisUnit: "Cumulative experience gained",
+    });
+    // The two Attack rows share their visible name, so the keys (used by the
+    // table's keyed v-for) must differ by member or Vue's list diff corrupts.
+    expect(
+      rows.map(function getNameAndKey({ name, key }) {
+        return { name, key };
+      }),
+    ).toEqual([
+      { name: "Alice", key: "member Alice" },
+      { name: "Attack", key: "skill Attack Alice" },
+      { name: "Bob", key: "member Bob" },
+      { name: "Attack", key: "skill Attack Bob" },
+    ]);
+  });
+
   it("uses calendar periods in UTC including across daylight saving changes", function testPresets() {
     const end = new Date("2026-03-30T12:00:00Z");
     expect(rangeForPeriod("Day", end).start.toISOString()).toBe("2026-03-29T12:00:00.000Z");


### PR DESCRIPTION
Noticed the "Experience gained in the visible period" table on the history page sometimes goes a bit haywire. The same skill can show up twice under one player, and sometimes a row appears in the wrong colour with another player's xp stuck inside someone else's block.

Turns out the rows were keyed by skill name (plus icon and header flag), so when two members gained the same skill in the visible window they got identical Vue keys. Vue's keyed list diff really doesn't like that, and any re-render can leave stale rows lying around.

This PR keys rows by member + skill instead (`member <name>` / `skill <skill> <member>`) and adds a regression test for two members gaining the same skill.

<details>
<summary>How to reproduce</summary>

1. Open `/group/history` with the skill filter on Overall
2. Works best with a group where a different member leads in different time windows, which is pretty normal for real groups
3. Click Day, then Week, then Month
4. The table under the chart ends up with duplicated or misplaced rows, e.g. Magic listed twice under one player, or a row in another member's colour

Zooming and panning the chart can trigger it too, anything that reorders the table rows will do it. In dev mode Vue also logs "Duplicate keys found during update" to the console when it happens.

</details>

## Screenshots

before clicking day -> week ->  month

<img width="1397" height="688" alt="Screenshot 2026-09-11 at 22 50 37" src="https://github.com/user-attachments/assets/40b7238d-665f-477b-8b55-acd5b91236d4" />

after (notice the hunter row is not mine) (aplogies these screenshots are horrible 😆 )

<img width="1397" height="709" alt="Screenshot 2026-09-11 at 22 50 49" src="https://github.com/user-attachments/assets/b87cb9b6-b420-450f-92d3-bceafbcb0a77" />
